### PR TITLE
p44/ex3 fix: Use sin(𝛼) in solution solution for tan(𝛼)

### DIFF
--- a/gelfand-trigonometry-solutions.tex
+++ b/gelfand-trigonometry-solutions.tex
@@ -784,7 +784,7 @@ $\sin^{2}{45\degree} = \left(\dfrac{1}{\sqrt{2}}\right)^2 = \dfrac{1}{2}$
 \hline
 ~              & $\sin{\alpha}$                                      & $\cos{\alpha}$                           & $\tan{\alpha}$                                      & $\cot{\alpha}$ \\
 \hline
-$\sin{\alpha}$ & $\sin{\alpha}$                                      & $\sqrt{1 - \sin^{2}{\alpha}}$            & $\dfrac{a}{\sqrt{1 - \sin^{2}{\alpha}}}$            & $\dfrac{\sqrt{1 - \sin^{2}{\alpha}}}{\sin{\alpha}}$ \\
+$\sin{\alpha}$ & $\sin{\alpha}$                                      & $\sqrt{1 - \sin^{2}{\alpha}}$            & $\dfrac{\sin{\alpha}}{\sqrt{1 - \sin^{2}{\alpha}}}$            & $\dfrac{\sqrt{1 - \sin^{2}{\alpha}}}{\sin{\alpha}}$ \\
 \hline
 $\cos{\alpha}$ & $\sqrt{1 - \cos^{2}{\alpha}}$                       & $\cos{\alpha}$                           & $\dfrac{\sqrt{1 - \cos^{2}{\alpha}}}{\cos{\alpha}}$ & $\dfrac{\cos{\alpha}}{\sqrt{1 - \cos^{2}{\alpha}}}$ \\
 \hline


### PR DESCRIPTION
There is a mistake in the solution to exercise 3, page 44. In the first row of the table, under the heading "Tan alpha", the solution is given as ```a / sqrt(1 - sin²𝛼)```, but the textbook gives the answer in terms of sin 𝛼: ```sin 𝛼 / sqrt(1 - sin²𝛼)```.

This PR fixes the solution to be in-line with what the authors suggest.